### PR TITLE
If using an IAM role, with AWS SDK for PHP v3.33, the Domain and CustomDomain attributes are excluded from describeUserPool results.

### DIFF
--- a/acp/main_module.php
+++ b/acp/main_module.php
@@ -121,7 +121,6 @@ class main_module
 								. $config['cogauth_aws_region'] . '.amazoncognito.com');
 						}
 						else {
-							trigger_error("Neither Domain or CustomDomain set on UserPool ".$result['UserPool']["Id"].". Ensure your aws sdk for php is up to date. Version 3.33.4 did not return the Domain or CustomDomain fields correctly when using an IAM role.");
 							trigger_error($language->lang('COGAUTH_DESCRIBE_USERPOOL_DOMAIN_NOT_SET').$result['UserPool']["Id"].'. '.$language->lang('COGAUTH_DESCRIBE_USERPOOL_DOMAIN_NOT_SET_EXTRA'));
 						}
 

--- a/acp/main_module.php
+++ b/acp/main_module.php
@@ -115,10 +115,14 @@ class main_module
 						{
 							$config->set('cogauth_hosted_ui_domain',$result['UserPool']['CustomDomain']);
 						}
-						else
+						else if ($result['UserPool']['Domain'])
 						{
 							$config->set('cogauth_hosted_ui_domain',$result['UserPool']['Domain'] . '.auth.'
 								. $config['cogauth_aws_region'] . '.amazoncognito.com');
+						}
+						else {
+							trigger_error("Neither Domain or CustomDomain set on UserPool ".$result['UserPool']["Id"].". Ensure your aws sdk for php is up to date. Version 3.33.4 did not return the Domain or CustomDomain fields correctly when using an IAM role.");
+							trigger_error($language->lang('COGAUTH_DESCRIBE_USERPOOL_DOMAIN_NOT_SET').$result['UserPool']["Id"].'. '.$language->lang('COGAUTH_DESCRIBE_USERPOOL_DOMAIN_NOT_SET_EXTRA'));
 						}
 
 						// Add the phpbb_user_id custom attribute is it does not exist.

--- a/composer.lock
+++ b/composer.lock
@@ -4,27 +4,77 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0bc5895b70929ef5b39cebf53702b265",
+    "content-hash": "f226cd6227991e5b9ba22911786a3e43",
     "packages": [
         {
-            "name": "aws/aws-sdk-php",
-            "version": "3.33.4",
+            "name": "aws/aws-crt-php",
+            "version": "v1.0.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "586a9c0e52664cfc4d2d91f9dcdf3ea48d143162"
+                "url": "https://github.com/awslabs/aws-crt-php.git",
+                "reference": "3942776a8c99209908ee0b287746263725685732"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/586a9c0e52664cfc4d2d91f9dcdf3ea48d143162",
-                "reference": "586a9c0e52664cfc4d2d91f9dcdf3ea48d143162",
+                "url": "https://api.github.com/repos/awslabs/aws-crt-php/zipball/3942776a8c99209908ee0b287746263725685732",
+                "reference": "3942776a8c99209908ee0b287746263725685732",
                 "shasum": ""
             },
             "require": {
-                "guzzlehttp/guzzle": "^5.3.1|^6.2.1",
-                "guzzlehttp/promises": "~1.0",
-                "guzzlehttp/psr7": "^1.4.1",
-                "mtdowling/jmespath.php": "~2.2",
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35|^5.4.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "AWS SDK Common Runtime Team",
+                    "email": "aws-sdk-common-runtime@amazon.com"
+                }
+            ],
+            "description": "AWS Common Runtime for PHP",
+            "homepage": "http://aws.amazon.com/sdkforphp",
+            "keywords": [
+                "amazon",
+                "aws",
+                "crt",
+                "sdk"
+            ],
+            "time": "2021-09-03T22:57:30+00:00"
+        },
+        {
+            "name": "aws/aws-sdk-php",
+            "version": "3.215.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/aws/aws-sdk-php.git",
+                "reference": "79c4ffdf93cdcc7be9196ae2e22f0d0323cb2557"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/79c4ffdf93cdcc7be9196ae2e22f0d0323cb2557",
+                "reference": "79c4ffdf93cdcc7be9196ae2e22f0d0323cb2557",
+                "shasum": ""
+            },
+            "require": {
+                "aws/aws-crt-php": "^1.0.2",
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-simplexml": "*",
+                "guzzlehttp/guzzle": "^5.3.3|^6.2.1|^7.0",
+                "guzzlehttp/promises": "^1.4.0",
+                "guzzlehttp/psr7": "^1.7.0|^2.0",
+                "mtdowling/jmespath.php": "^2.6",
                 "php": ">=5.5"
             },
             "require-dev": {
@@ -33,20 +83,22 @@
                 "behat/behat": "~3.0",
                 "doctrine/cache": "~1.4",
                 "ext-dom": "*",
-                "ext-json": "*",
                 "ext-openssl": "*",
-                "ext-pcre": "*",
-                "ext-simplexml": "*",
-                "ext-spl": "*",
+                "ext-pcntl": "*",
+                "ext-sockets": "*",
                 "nette/neon": "^2.3",
-                "phpunit/phpunit": "^4.8.35|^5.4.0",
-                "psr/cache": "^1.0"
+                "paragonie/random_compat": ">= 2",
+                "phpunit/phpunit": "^4.8.35|^5.4.3",
+                "psr/cache": "^1.0",
+                "psr/simple-cache": "^1.0",
+                "sebastian/comparator": "^1.2.3"
             },
             "suggest": {
                 "aws/aws-php-sns-message-validator": "To validate incoming SNS notifications",
                 "doctrine/cache": "To use the DoctrineCacheAdapter",
                 "ext-curl": "To send requests using cURL",
-                "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages"
+                "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages",
+                "ext-sockets": "To use client-side monitoring"
             },
             "type": "library",
             "extra": {
@@ -55,12 +107,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Aws\\": "src/"
-                },
                 "files": [
                     "src/functions.php"
-                ]
+                ],
+                "psr-4": {
+                    "Aws\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -84,12 +136,7 @@
                 "s3",
                 "sdk"
             ],
-            "support": {
-                "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
-                "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/master"
-            },
-            "time": "2017-08-21T20:34:30+00:00"
+            "time": "2022-03-18T18:16:01+00:00"
         },
         {
             "name": "brick/math",
@@ -1424,5 +1471,5 @@
         "ext-curl": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "1.1.0"
 }

--- a/language/en/common.php
+++ b/language/en/common.php
@@ -38,6 +38,8 @@ $lang = array_merge($lang, array(
 	'COGAUTH_AWS_SECRET_EXPLAIN'	=> 'Leave blank to use IAM Role',
 	'COGAUTH_AWS_KEY_EXPLAIN'		=> 'Leave blank to use IAM Role',
 
+	'COGAUTH_DESCRIBE_USERPOOL_DOMAIN_NOT_SET' => "Neither Domain or CustomDomain set on UserPool ",
+	'COGAUTH_DESCRIBE_USERPOOL_DOMAIN_NOT_SET_EXTRA' => "Ensure your aws sdk for php is up to date. Version 3.33.4 did not return the Domain or CustomDomain fields correctly when using an IAM role",
 
 	'COGAUTH_CLIENT_ID_EXPLAIN'		=> 'AWS Cognito Client ID',
 	'COGAUTH_POOL_ID_EXPLAIN'		=> 'AWS Cognito User Pool ID',


### PR DESCRIPTION
Updated SDK version to latest and added an error handling in case neither is set in the response.